### PR TITLE
openssl/ts: add set_store for TsVerifyContext

### DIFF
--- a/openssl-sys/src/ts.rs
+++ b/openssl-sys/src/ts.rs
@@ -2,6 +2,7 @@ use libc::*;
 
 use crate::X509_ALGOR;
 use crate::X509;
+use crate::X509_STORE;
 use crate::EVP_PKEY;
 use crate::EVP_MD;
 use crate::ASN1_INTEGER;
@@ -96,6 +97,11 @@ extern "C" {
         hexstr: *mut c_uchar,
         length: c_long,
     ) -> *mut c_uchar;
+    #[cfg(ossl110)]
+    pub fn TS_VERIFY_CTX_set_store(
+        ctx: *mut TS_VERIFY_CTX,
+        store: *mut X509_STORE,
+    ) -> *mut X509_STORE;
     pub fn TS_RESP_verify_response(ctx: *mut TS_VERIFY_CTX, response: *mut TS_RESP) -> c_int;
 
     pub fn TS_REQ_to_TS_VERIFY_CTX(req: *mut TS_REQ, ctx: *mut TS_VERIFY_CTX)

--- a/openssl/src/ts.rs
+++ b/openssl/src/ts.rs
@@ -15,6 +15,7 @@ use crate::error::ErrorStack;
 use crate::hash::MessageDigest;
 use crate::pkey::{HasPrivate, PKeyRef};
 use crate::x509::{X509Algorithm, X509Ref};
+use crate::x509::store::X509Store;
 use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
@@ -253,6 +254,30 @@ impl TsVerifyContext {
                 ptr::null_mut(),
             ))?;
             Ok(TsVerifyContext::from_ptr(ctx))
+        }
+    }
+}
+
+impl TsVerifyContextRef {
+    /// Sets the X.509 certificate store used for signature verification.
+    ///
+    /// The context takes ownership of `store`. Any previously-set store is freed.
+    ///
+    /// Requires OpenSSL 1.1.0 or newer.
+    ///
+    /// This corresponds to `TS_VERIFY_CTX_set_store`.
+    #[cfg(ossl110)]
+    pub fn set_store(&mut self, store: X509Store) -> Result<(), ErrorStack> {
+        unsafe {
+            let raw = store.as_ptr();
+            // Transfer ownership to the TS_VERIFY_CTX; prevent X509Store from freeing it.
+            std::mem::forget(store);
+            let old = ffi::TS_VERIFY_CTX_set_store(self.as_ptr(), raw);
+            // Drop any previously-set store returned by the setter.
+            if !old.is_null() {
+                X509Store::from_ptr(old);
+            }
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
Add `TS_VERIFY_CTX_set_store` FFI binding to `openssl-sys/src/ts.rs` and a corresponding `TsVerifyContextRef::set_store()` safe wrapper to `openssl/src/ts.rs`, both gated under `#[cfg(ossl110)]`.

This is needed by the SPS auditwriter to supply a custom CA trust store when verifying TSA timestamp signatures (ADO #651096). Without this, the verify context built from a request has no trust anchors and signature verification always fails for certificates signed by a private CA.

The C function `TS_VERIFY_CTX_set_store` has existed since OpenSSL 1.1.0; this just exposes it through the existing safe wrapper layer.