### PR TITLE
ts: add missing timestamping wrappers and policy getter

### DIFF
--- a/openssl-sys/src/ts.rs
+++ b/openssl-sys/src/ts.rs
@@ -124,6 +124,7 @@ extern "C" {
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {
         extern "C" {
+            pub fn TS_REQ_get_policy_id(a: *const TS_REQ) -> *mut ASN1_OBJECT;
             pub fn TS_REQ_set_policy_id(
                 a: *mut TS_REQ,
                 policy: *const ASN1_OBJECT
@@ -135,6 +136,7 @@ cfg_if! {
         }
     } else {
         extern "C" {
+            pub fn TS_REQ_get_policy_id(a: *mut TS_REQ) -> *mut ASN1_OBJECT;
             pub fn TS_REQ_set_policy_id(
                 a: *mut TS_REQ,
                 policy: *mut ASN1_OBJECT

--- a/openssl-sys/src/ts.rs
+++ b/openssl-sys/src/ts.rs
@@ -33,14 +33,21 @@ cfg_if! {
     }
 }
 
-/// Server-side flag for `TS_RESP_CTX_add_flags`: include the signer's name
-/// (DN) in the response (equivalent to `tsa_name = yes` in an OpenSSL TSA
-/// configuration file).
+/// Server-side flag for `TS_RESP_CTX_add_flags`: include the TSA name in the
+/// response (equivalent to `tsa_name = yes` in an OpenSSL TSA configuration
+/// file).
 ///
 /// NOTE: Numerically identical to `TS_VFY_SIGNATURE` (`0x01`), which belongs
 /// to the *verify*-context flag space (`TS_VERIFY_CTX`). The two constants
 /// are unrelated and must not be used interchangeably.
 pub const TS_TSA_NAME: c_uint = 0x01;
+/// Server-side flag for `TS_RESP_CTX_add_flags`: set the ordering field to
+/// true in the response.
+pub const TS_ORDERING: c_uint = 0x02;
+/// Server-side flag for `TS_RESP_CTX_add_flags`: include the signer
+/// certificate and the other configured certificates in the ESS signing
+/// certificate attribute.
+pub const TS_ESS_CERT_ID_CHAIN: c_uint = 0x04;
 
 pub const TS_VFY_SIGNATURE: c_uint = 0x1;
 pub const TS_VFY_VERSION: c_uint = 0x2;

--- a/openssl-sys/src/ts.rs
+++ b/openssl-sys/src/ts.rs
@@ -33,6 +33,15 @@ cfg_if! {
     }
 }
 
+/// Server-side flag for `TS_RESP_CTX_add_flags`: include the signer's name
+/// (DN) in the response (equivalent to `tsa_name = yes` in an OpenSSL TSA
+/// configuration file).
+///
+/// NOTE: Numerically identical to `TS_VFY_SIGNATURE` (`0x01`), which belongs
+/// to the *verify*-context flag space (`TS_VERIFY_CTX`). The two constants
+/// are unrelated and must not be used interchangeably.
+pub const TS_TSA_NAME: c_uint = 0x01;
+
 pub const TS_VFY_SIGNATURE: c_uint = 0x1;
 pub const TS_VFY_VERSION: c_uint = 0x2;
 pub const TS_VFY_POLICY: c_uint = 0x4;
@@ -96,6 +105,7 @@ extern "C" {
         hexstr: *mut c_uchar,
         length: c_long,
     ) -> *mut c_uchar;
+    pub fn TS_VERIFY_CTX_set_flags(ctx: *mut TS_VERIFY_CTX, flags: c_int) -> c_int;
     pub fn TS_RESP_verify_response(ctx: *mut TS_VERIFY_CTX, response: *mut TS_RESP) -> c_int;
 
     pub fn TS_REQ_to_TS_VERIFY_CTX(req: *mut TS_REQ, ctx: *mut TS_VERIFY_CTX)
@@ -106,6 +116,7 @@ extern "C" {
     pub fn TS_RESP_CTX_set_signer_cert(ctx: *mut TS_RESP_CTX, signer: *mut X509) -> c_int;
     pub fn TS_RESP_CTX_set_signer_key(ctx: *mut TS_RESP_CTX, key: *mut EVP_PKEY) -> c_int;
     pub fn TS_RESP_CTX_add_md(ctx: *mut TS_RESP_CTX, md: *const EVP_MD) -> c_int;
+    pub fn TS_RESP_CTX_add_flags(ctx: *mut TS_RESP_CTX, flags: c_int);
 
     pub fn TS_RESP_create_response(ctx: *mut TS_RESP_CTX, req_bio: *mut BIO) -> *mut TS_RESP;
 }

--- a/openssl/src/ts.rs
+++ b/openssl/src/ts.rs
@@ -257,6 +257,30 @@ impl TsVerifyContext {
     }
 }
 
+impl TsVerifyContextRef {
+    /// Replaces the verify flags on this context.
+    ///
+    /// This corresponds to `TS_VERIFY_CTX_set_flags`.
+    ///
+    /// # Safety note
+    ///
+    /// Setting [`VerifyFlags::SIGNATURE`] (or any combined flag that includes
+    /// it, such as [`VerifyFlags::ALL_IMPRINT`] or [`VerifyFlags::ALL_DATA`])
+    /// without first configuring a trust store will cause a NULL-pointer
+    /// dereference inside OpenSSL when [`TsResp::verify`] is called. Until a
+    /// `set_store` wrapper is available in this crate, callers must not include
+    /// `SIGNATURE` in `flags`.
+    pub fn set_flags(&mut self, flags: VerifyFlags) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::TS_VERIFY_CTX_set_flags(
+                self.as_ptr(),
+                flags.bits() as c_int,
+            ))
+            .map(|_| ())
+        }
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::TS_RESP_CTX;
     fn drop = ffi::TS_RESP_CTX_free;
@@ -269,6 +293,18 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl TsRespContextRef {
+    /// Adds flags to the response context.
+    ///
+    /// Pass `ffi::TS_TSA_NAME` to include the signer certificate in responses
+    /// (equivalent to `tsa_name = yes` in an OpenSSL TSA configuration file).
+    ///
+    /// This corresponds to `TS_RESP_CTX_add_flags`.
+    pub fn add_flags(&mut self, flags: u32) {
+        unsafe {
+            ffi::TS_RESP_CTX_add_flags(self.as_ptr(), flags as c_int);
+        }
+    }
+
     /// Creates a signed timestamp response for the request.
     ///
     /// This corresponds to `TS_RESP_create_response`.

--- a/openssl/src/ts.rs
+++ b/openssl/src/ts.rs
@@ -245,6 +245,15 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Flags controlling timestamp response generation behaviour.
+    pub struct RespFlags: c_uint {
+        const TSA_NAME = ffi::TS_TSA_NAME;
+        const ORDERING = ffi::TS_ORDERING;
+        const ESS_CERT_ID_CHAIN = ffi::TS_ESS_CERT_ID_CHAIN;
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::TS_VERIFY_CTX;
     fn drop = ffi::TS_VERIFY_CTX_free;
@@ -309,13 +318,15 @@ foreign_type_and_impl_send_sync! {
 impl TsRespContextRef {
     /// Adds flags to the response context.
     ///
-    /// Pass `ffi::TS_TSA_NAME` to include the signer certificate in responses
-    /// (equivalent to `tsa_name = yes` in an OpenSSL TSA configuration file).
+    /// Pass [`RespFlags::TSA_NAME`] to include the TSA name in responses,
+    /// [`RespFlags::ORDERING`] to set the ordering field to true, and
+    /// [`RespFlags::ESS_CERT_ID_CHAIN`] to include the configured certificate
+    /// chain in the ESS signing certificate attribute.
     ///
     /// This corresponds to `TS_RESP_CTX_add_flags`.
-    pub fn add_flags(&mut self, flags: u32) {
+    pub fn add_flags(&mut self, flags: RespFlags) {
         unsafe {
-            ffi::TS_RESP_CTX_add_flags(self.as_ptr(), flags as c_int);
+            ffi::TS_RESP_CTX_add_flags(self.as_ptr(), flags.bits() as c_int);
         }
     }
 

--- a/openssl/src/ts.rs
+++ b/openssl/src/ts.rs
@@ -113,6 +113,20 @@ impl TsReqRef {
         to_der,
         ffi::i2d_TS_REQ
     }
+
+    /// Returns the policy OID from the request, or `None` if not set.
+    ///
+    /// This corresponds to `TS_REQ_get_policy_id`.
+    pub fn policy_id(&self) -> Option<&Asn1ObjectRef> {
+        unsafe {
+            let ptr = ffi::TS_REQ_get_policy_id(self.as_ptr());
+            if ptr.is_null() {
+                None
+            } else {
+                Some(Asn1ObjectRef::from_ptr(ptr))
+            }
+        }
+    }
 }
 
 impl TsReq {


### PR DESCRIPTION
## Summary
- add `TS_VERIFY_CTX_set_flags` and `TS_RESP_CTX_add_flags` wrappers
- add `TS_REQ_get_policy_id` FFI and `TsReqRef::policy_id` getter

## Branches
- head: `fbakonyi:timestamping-0.10.78`
- base: `timestamping-0.10.78`